### PR TITLE
Belarus, Gorod Minsk shortCode HO to HM

### DIFF
--- a/data.js
+++ b/data.js
@@ -1641,7 +1641,7 @@ return [
       },
       {
         "name": "Gorod Minsk",
-        "shortCode": "HO"
+        "shortCode": "HM"
       },
       {
         "name": "Homiel voblast",


### PR DESCRIPTION
Belarus, City of Minsk ISO code should be HM instead of HO