### PR TITLE
Changes to regions of Sweden:

### DIFF
--- a/data.json
+++ b/data.json
@@ -14985,27 +14985,27 @@
                 "shortCode": "K"
             },
             {
-                "name": "Dalarnas",
+                "name": "Dalarna",
                 "shortCode": "W"
             },
             {
-                "name": "Gotlands",
+                "name": "Gävleborg",
                 "shortCode": "X"
             },
             {
-                "name": "Gavleborgs",
+                "name": "Gotland",
                 "shortCode": "I"
             },
             {
-                "name": "Hallands",
+                "name": "Halland",
                 "shortCode": "N"
             },
             {
-                "name": "Jamtlands",
+                "name": "Jämtland",
                 "shortCode": "Z"
             },
             {
-                "name": "Jonkopings",
+                "name": "Jönköping",
                 "shortCode": "F"
             },
             {
@@ -15013,27 +15013,27 @@
                 "shortCode": "H"
             },
             {
-                "name": "Kronobergs",
+                "name": "Kronoberg",
                 "shortCode": "G"
             },
             {
-                "name": "Norrbottens",
+                "name": "Norrbotten",
                 "shortCode": "BD"
             },
             {
-                "name": "Orebro",
+                "name": "Örebro",
                 "shortCode": "T"
             },
             {
-                "name": "Ostergotlands",
+                "name": "Östergötland",
                 "shortCode": "E"
             },
             {
-                "name": "Skane",
+                "name": "Skåne",
                 "shortCode": "M"
             },
             {
-                "name": "Sodermanlands",
+                "name": "Södermanland",
                 "shortCode": "D"
             },
             {
@@ -15041,23 +15041,27 @@
                 "shortCode": "AB"
             },
             {
-                "name": "Varmlands",
+                "name": "Uppsala",
+                "shortCode": "C"
+            },
+            {
+                "name": "Värmland",
                 "shortCode": "S"
             },
             {
-                "name": "Vasterbottens",
+                "name": "Västerbotten",
                 "shortCode": "AC"
             },
             {
-                "name": "Vasternorrlands",
+                "name": "Västernorrland",
                 "shortCode": "Y"
             },
             {
-                "name": "Vastmanlands",
+                "name": "Västmanland",
                 "shortCode": "U"
             },
             {
-                "name": "Vastra Gotalands",
+                "name": "Västra Götaland",
                 "shortCode": "O"
             }
         ]


### PR DESCRIPTION
1. Removed Swedish genitive "s" from county names for English usage.
2. Changed to Swedish orthography using letters Å, Ä and Ö.
3. Added Uppsala county, making the list complete (21 counties).
4. Switched "Gotland" and "Gävleborg" counties to map to correct codes.