### PR TITLE
Translate Belgian regions to neutral English

### DIFF
--- a/data.js
+++ b/data.js
@@ -1670,15 +1670,15 @@ return [
     "countryShortCode": "BE",
     "regions": [
       {
-        "name": "Bruxelles-Capitale",
+        "name": "Brussels",
         "shortCode": "BRU"
       },
       {
-        "name": "Région Flamande",
+        "name": "Flanders",
         "shortCode": "VLG"
       },
       {
-        "name": "Région Wallonië",
+        "name": "Wallonia",
         "shortCode": "WAL"
       }
     ]

--- a/data.json
+++ b/data.json
@@ -1629,15 +1629,15 @@
         "countryName": "Belgium",
         "countryShortCode": "BE",
         "regions": [{
-                "name": "Bruxelles-Capitale",
+                "name": "Brussels",
                 "shortCode": "BRU"
             },
             {
-                "name": "Région Flamande",
+                "name": "Flanders",
                 "shortCode": "VLG"
             },
             {
-                "name": "Région Wallonië",
+                "name": "Wallonia",
                 "shortCode": "WAL"
             }
         ]


### PR DESCRIPTION
For those of you that don't know about Belgium: we are a country with 3 official languages: Dutch, French and German. 

Belgian Dutch speaking people mostly don't like French, Belgian French speaking people mostly don't like Dutch. 
The current region translations use French which might ruffle some feathers with the Dutch speaking people. That is the reason why it might be better to just change it to neutral English.