### PR TITLE
changes "Macedonia" to "North Macedonia"

### DIFF
--- a/data.js
+++ b/data.js
@@ -8557,7 +8557,7 @@ return [
     ]
   },
   {
-    "countryName": "Macedonia, Republic of",
+    "countryName": "North Macedonia, Republic of",
     "countryShortCode": "MK",
     "regions": [
       {


### PR DESCRIPTION
In accordance with the resolution of the long-standing naming dispute, "The Republic of Macedonia" has been officially renamed "The Republic of North Macedonia." This occurred early last year.

[Recognition of the change by the UN.](https://www.un.org/press/en/2019/sgsm19460.doc.htm)