### PR TITLE
Update P'ing-tung regions

### DIFF
--- a/data.json
+++ b/data.json
@@ -15349,8 +15349,8 @@
                 "shortCode": "NWT"
             },
             {
-                "name": "P'ing-chung",
-                "shortCode": "PIF"
+                "name": "P'ing-tung",
+                "shortCode": "PING"
             },
             {
                 "name": "T'ai-chung",


### PR DESCRIPTION
Since there is no P'ing-chung in Taiwan, I think it should be P'ing-tung.

This PR update to the P'ing-tung regions