### PR TITLE
Do not exclude Reykjavík from Iceland region 1

### DIFF
--- a/data.json
+++ b/data.json
@@ -5779,7 +5779,7 @@
                 "shortCode": "7"
             },
             {
-                "name": "Höfuðborgarsvæði utan Reykjavíkur",
+                "name": "Höfuðborgarsvæði",
                 "shortCode": "1"
             },
             {


### PR DESCRIPTION
From a customer of ours: 

> Region includes "Höfuðborgarsvæði utan Reykjavíkur" (Capital region not including Reykjavík) but "Reykjavík" (the capital city where 1/3 of the country lives) isn't an option.

> It would make sense to just change "Höfuðborgarsvæði utan Reykjavíkur" to "Höfuðborgarsvæðið" (The capital region)

This also matches up with ISO's regions for Iceland