### PR TITLE
Corrected typo

### DIFF
--- a/data.js
+++ b/data.js
@@ -15409,7 +15409,7 @@ return [
         "shortCode": "AR"
       },
       {
-        "name": "Appenzell Innerhoden",
+        "name": "Appenzell Innerrhoden",
         "shortCode": "AI"
       },
       {


### PR DESCRIPTION
Innerhoden should read: Innerrhoden

Fun fact: It currently reads “inside testicle”. Let’s please fix this :)