### PR TITLE
Change Mexico City short code to the new one imposed in nov 2016

### DIFF
--- a/data.json
+++ b/data.json
@@ -9831,7 +9831,7 @@
       },
       {
         "name": "Ciudad de México",
-        "shortCode": "DIF"
+        "shortCode": "CMX"
       },
       {
         "name": "Chiapas",


### PR DESCRIPTION
Correct Mexico City Short code

[as per](https://es.wikipedia.org/wiki/Plantilla:Abreviaciones_de_los_estados_de_M%C3%A9xico)