### PR TITLE
Rename Swaziland to Eswatini

### DIFF
--- a/data.json
+++ b/data.json
@@ -15277,7 +15277,7 @@
     ]
   },
   {
-    "countryName": "Swaziland",
+    "countryName": "Eswatini",
     "countryShortCode": "SZ",
     "regions": [
       {


### PR DESCRIPTION
Eswatini became the country's official name in April 2018