### PR TITLE
Rename Ilfov region for Romania

### DIFF
--- a/data.json
+++ b/data.json
@@ -12659,7 +12659,7 @@
         "shortCode": "RO-IS"
       },
       {
-        "name": "Iifov",
+        "name": "Ilfov",
         "shortCode": "RO-IF"
       },
       {


### PR DESCRIPTION
The correct name for the region is ILFOV - https://en.wikipedia.org/wiki/Ilfov_County 

Also related to this issue - https://github.com/country-regions/country-region-data/issues/132 

Thanks! 