### PR TITLE
Fix Spain Almeria code

### DIFF
--- a/data.json
+++ b/data.json
@@ -14874,7 +14874,7 @@
       },
       {
         "name": "Almería",
-        "shortCode": "AN"
+        "shortCode": "AL"
       },
       {
         "name": "Araba/Álava",


### PR DESCRIPTION
Almeria, a region from Spain, is incorrectly identified as 'AN' instead of 'AL'.
'AN' is the code for 'Andalucia'

Reference: ISO 3166-2:ES-AL