### PR TITLE
Updated regions for country Zambia

### DIFF
--- a/data.json
+++ b/data.json
@@ -19141,6 +19141,10 @@
         "shortCode": "09"
       },
       {
+        "name": "Muchinga",
+        "shortCode": "10"
+      },
+      {
         "name": "Northern",
         "shortCode": "05"
       },


### PR DESCRIPTION
#138 

In 2011, Zambia divided the Northern province into two by creating Munching province 