### PR TITLE
Update typo in data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -11378,7 +11378,7 @@
     ]
   },
   {
-    "countryName": "Palestine, State of",
+    "countryName": "Palestine",
     "countryShortCode": "PS",
     "regions": [
       {


### PR DESCRIPTION
"Palestine, State of" must be a typo because the actual country name is "Palestine"